### PR TITLE
Improved envy:get's -specs

### DIFF
--- a/src/envy.erl
+++ b/src/envy.erl
@@ -45,8 +45,10 @@
                                 'pos_integer' |
                                 'positive_integer' |
                                 'string'.
+-type envy_type_constraints() :: envy_type_constraint() |
+                                 nonempty_list(envy_type_constraint()).
 
--spec fun_ex(envy_type_constraint() | nonempty_list(envy_type_constraint())) -> envy_type_validator().
+-spec fun_ex(envy_type_constraints()) -> envy_type_validator().
 fun_ex(any) -> fun(_) -> true end;
 fun_ex(atom) -> fun is_atom/1;
 fun_ex(binary) -> fun is_binary/1;
@@ -68,7 +70,7 @@ fun_ex(list) -> fun_ex(string);
 fun_ex(string) -> fun is_list/1;
 fun_ex(F) when is_function(F) -> F.
 
--spec get(atom(), atom(), envy_type_constraint() ) -> any().
+-spec get(atom(), atom(), envy_type_constraints() ) -> any().
 get(Section, Item, TypeCheck) ->
     TypeCheckF = fun_ex(TypeCheck),
     case application:get_env(Section, Item) of
@@ -85,7 +87,7 @@ get(Section, Item, TypeCheck) ->
             error(config_missing_item)
     end.
 
--spec get(atom(), atom(), any(), envy_type_constraint() ) -> any().
+-spec get(atom(), atom(), any(), envy_type_constraints() ) -> any().
 get(Section, Item, Default, TypeCheck) ->
     TypeCheckF = fun_ex(TypeCheck),
     case application:get_env(Section, Item) of


### PR DESCRIPTION
Dialyzer specs for envy:get/3 and /4 are only say that they accept one
envy_type_constraint, but in fact they can also accept a nonempty_list
of constraints.

Applying this change in chef/oc_erchef removes the following dialyzer errors:

```
chef_s3.erl:76: Function generate_presigned_urls/5 has no local return
chef_s3.erl:88: Function generate_presigned_url/5 has no local return
chef_s3.erl:93: Function generate_presigned_url/6 will never be called
chef_s3.erl:130: Function base64_checksum/1 will never be called
chef_s3.erl:143: Function headers_for_type/2 will never be called
chef_s3.erl:161: Function get_external_config/1 has no local return
chef_s3.erl:179: Function s3_external_url/1 has no local return
chef_s3.erl:180: The call envy:get('chef_objects','s3_external_url',['atom' | 'string',...]) breaks the contract (atom(),atom(),envy_type_constraint()) -> any()
```

It's the last one that it really fixes, but you know dialyzer :D