### PR TITLE
Add envy:one_of helper method

### DIFF
--- a/src/envy.erl
+++ b/src/envy.erl
@@ -24,7 +24,8 @@
 -module(envy).
 
 -export([get/3,
-         get/4
+         get/4,
+         one_of/1
         ]).
 
 -include_lib("eunit/include/eunit.hrl").
@@ -69,6 +70,12 @@ fun_ex(List) when is_list(List) ->
 fun_ex(list) -> fun_ex(string);
 fun_ex(string) -> fun is_list/1;
 fun_ex(F) when is_function(F) -> F.
+
+-spec one_of(list()) -> function().
+one_of(List) when is_list(List) ->
+    fun(Item) ->
+            lists:member(Item, List)
+    end.
 
 -spec get(atom(), atom(), envy_type_constraints() ) -> any().
 get(Section, Item, TypeCheck) ->

--- a/test/envy_test.erl
+++ b/test/envy_test.erl
@@ -39,6 +39,8 @@ get_simple_test_() ->
              application:set_env(testing, invalid, {junk}),
              application:set_env(testing, nival, -1),
              application:set_env(testing, zival, 0),
+             application:set_env(testing, one_of_many, wombat),
+             application:set_env(testing, not_one_of_many, dne),
              ok
      end,
      fun(_) ->
@@ -88,7 +90,13 @@ get_simple_test_() ->
        },
       {"composite test fails if all fail",
        ?_test(?assertError(config_bad_type, envy:get(testing, nival, [pos_integer, non_neg_integer])))
-       }
+      },
+      {"envy:one_of validates against a list",
+       ?_test(?assertEqual(wombat, envy:get(testing, one_of_many, envy:one_of([wombat, turtle]))))
+      },
+      {"envy:one_of fails on item not in list",
+       ?_test(?assertError(config_bad_type, envy:get(testing, not_one_of_many, envy:one_of([wombat, turtle]))))
+      }
      ]}.
 
 


### PR DESCRIPTION
envy:one_of returns a fun that tests whether the passed configuration
item exist in a list of possible items.  This allows the user to write
type checks such as:

    envy:get(foo, bar, envy:one_of([a, b c])).