### PR TITLE
add new proplist_get to validate values out of a proplist

### DIFF
--- a/src/envy_parse.erl
+++ b/src/envy_parse.erl
@@ -25,7 +25,8 @@
 
 -export([to_ip/2,
          host_to_ip/2,
-         host_to_ip/3
+         host_to_ip/3,
+         parse_host_to_ip/2
         ]).
 
 -type envy_ip_preference() :: 'ipv4' | 'ipv6'.
@@ -46,6 +47,13 @@ maybe_parse({error, Error}, Host, _Preferences) ->
     erlang:error({Error, Host});
 maybe_parse({ok, IP}, _Host, _Preferences) ->
     IP.
+
+
+%% Section is used only to get the ip_mode rules.
+parse_host_to_ip(Section, HostString) ->
+    Preferences = envy:get(Section, ip_mode, [ipv4], list),
+    to_ip(HostString, Preferences).
+
 
 %% These functions look for a string typed key under Section, Item, and parses it down to
 %% an ipv4/ipv6 address based on a preferences string kept in Section, 'ip_mode'

--- a/test/envy_parse_test.erl
+++ b/test/envy_parse_test.erl
@@ -58,6 +58,10 @@ parse_to_ip_simple_test_() ->
 host_to_ip_default_value_test() ->
     ?assertEqual({127,0,0,1}, envy_parse:host_to_ip(bad_section, bad_key, "127.0.0.1")).
 
+parse_host_to_ip_test() ->
+    application:set_env(app_key, ip_mode, [ipv4]),
+    ?assertEqual({127,0,0,1}, envy_parse:parse_host_to_ip(app_key, "127.0.0.1")).
+
 host_to_ip_simple_test_() ->
     {foreach,
      fun() ->

--- a/test/envy_test.erl
+++ b/test/envy_test.erl
@@ -21,15 +21,36 @@
 %% @copyright 2012-2013 Mark Anderson
 
 -module(envy_test).
-
 -include_lib("eunit/include/eunit.hrl").
+-define(PROPLIST, [{ival, 1}, {sval, "one"}]).
 
-
+proplist_get_simple_test_() ->
+     [{"fails for missing",
+       ?_test(?assertError(config_missing_item, envy:get(testing, no_such_value, any)))
+      },
+      {"fails for missing",
+       ?_test(?assertError(config_missing_item, envy:proplist_get(no_such_value, any, ?PROPLIST)))
+      },
+      {"integer test passes",
+       ?_test(?assertEqual(1, envy:proplist_get(ival, integer, ?PROPLIST)))
+      },
+      {"string test passes",
+       ?_test(?assertEqual("one", envy:proplist_get(sval, string, ?PROPLIST)))
+      },
+      {"integer type fails",
+       ?_test(?assertError(config_bad_type, envy:proplist_get(sval, integer, ?PROPLIST)))
+      },
+      {"default value is returned when key is not present",
+       ?_test(?assertEqual(10, envy:proplist_get(noval, integer, ?PROPLIST, 10)))
+      },
+      {"an erorr occurs when default value is returned and is not valid",
+       ?_test(?assertError(config_bad_type, envy:proplist_get(noval, integer, ?PROPLIST, "10")))
+      }
+     ].
 
 get_simple_test_() ->
     {foreach,
      fun() ->
-
              application:set_env(testing, ival, 1),
              application:set_env(testing, aval, an_atom),
              application:set_env(testing, bval, true),


### PR DESCRIPTION
For some in-flight sqerl work, was faced with needing envy's type validation, but applied to proplists.  To that end, I added envy:proplist_get - it's not a perfect fit with envy's intent to retrieve and validate application env params, but it does fit with the idea of validating configuration in general. 


